### PR TITLE
Switch from libgdal to libgdal-core

### DIFF
--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.22python3.10.____cpython.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,7 +28,7 @@ gdal:
 - '3.9'
 hdf5:
 - 1.14.3
-libgdal:
+libgdal_core:
 - '3.9'
 numpy:
 - '1.22'
@@ -44,7 +44,6 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - c_stdlib_version
-  - cdt_name
   - cuda_compiler
   - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.22python3.9.____cpython.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,7 +28,7 @@ gdal:
 - '3.9'
 hdf5:
 - 1.14.3
-libgdal:
+libgdal_core:
 - '3.9'
 numpy:
 - '1.22'
@@ -44,7 +44,6 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - c_stdlib_version
-  - cdt_name
   - cuda_compiler
   - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.23python3.11.____cpython.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,7 +28,7 @@ gdal:
 - '3.9'
 hdf5:
 - 1.14.3
-libgdal:
+libgdal_core:
 - '3.9'
 numpy:
 - '1.23'
@@ -44,7 +44,6 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - c_stdlib_version
-  - cdt_name
   - cuda_compiler
   - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.26python3.12.____cpython.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,7 +28,7 @@ gdal:
 - '3.9'
 hdf5:
 - 1.14.3
-libgdal:
+libgdal_core:
 - '3.9'
 numpy:
 - '1.26'
@@ -44,7 +44,6 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - c_stdlib_version
-  - cdt_name
   - cuda_compiler
   - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy1.22python3.10.____cpython.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,7 +28,7 @@ gdal:
 - '3.9'
 hdf5:
 - 1.14.3
-libgdal:
+libgdal_core:
 - '3.9'
 numpy:
 - '1.22'
@@ -44,7 +44,6 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - c_stdlib_version
-  - cdt_name
   - cuda_compiler
   - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy1.22python3.9.____cpython.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,7 +28,7 @@ gdal:
 - '3.9'
 hdf5:
 - 1.14.3
-libgdal:
+libgdal_core:
 - '3.9'
 numpy:
 - '1.22'
@@ -44,7 +44,6 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - c_stdlib_version
-  - cdt_name
   - cuda_compiler
   - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy1.23python3.11.____cpython.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,7 +28,7 @@ gdal:
 - '3.9'
 hdf5:
 - 1.14.3
-libgdal:
+libgdal_core:
 - '3.9'
 numpy:
 - '1.23'
@@ -44,7 +44,6 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - c_stdlib_version
-  - cdt_name
   - cuda_compiler
   - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12numpy1.26python3.12.____cpython.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,7 +28,7 @@ gdal:
 - '3.9'
 hdf5:
 - 1.14.3
-libgdal:
+libgdal_core:
 - '3.9'
 numpy:
 - '1.26'
@@ -44,7 +44,6 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - c_stdlib_version
-  - cdt_name
   - cuda_compiler
   - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13numpy1.22python3.10.____cpython.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,7 +28,7 @@ gdal:
 - '3.9'
 hdf5:
 - 1.14.3
-libgdal:
+libgdal_core:
 - '3.9'
 numpy:
 - '1.22'
@@ -44,7 +44,6 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - c_stdlib_version
-  - cdt_name
   - cuda_compiler
   - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13numpy1.22python3.9.____cpython.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,7 +28,7 @@ gdal:
 - '3.9'
 hdf5:
 - 1.14.3
-libgdal:
+libgdal_core:
 - '3.9'
 numpy:
 - '1.22'
@@ -44,7 +44,6 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - c_stdlib_version
-  - cdt_name
   - cuda_compiler
   - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13numpy1.23python3.11.____cpython.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,7 +28,7 @@ gdal:
 - '3.9'
 hdf5:
 - 1.14.3
-libgdal:
+libgdal_core:
 - '3.9'
 numpy:
 - '1.23'
@@ -44,7 +44,6 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - c_stdlib_version
-  - cdt_name
   - cuda_compiler
   - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13numpy1.26python3.12.____cpython.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,7 +28,7 @@ gdal:
 - '3.9'
 hdf5:
 - 1.14.3
-libgdal:
+libgdal_core:
 - '3.9'
 numpy:
 - '1.26'
@@ -44,7 +44,6 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - c_stdlib_version
-  - cdt_name
   - cuda_compiler
   - cuda_compiler_version
   - docker_image

--- a/.ci_support/osx_64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.10.____cpython.yaml
@@ -28,7 +28,7 @@ gdal:
 - '3.9'
 hdf5:
 - 1.14.3
-libgdal:
+libgdal_core:
 - '3.9'
 llvm_openmp:
 - '18'

--- a/.ci_support/osx_64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.9.____cpython.yaml
@@ -28,7 +28,7 @@ gdal:
 - '3.9'
 hdf5:
 - 1.14.3
-libgdal:
+libgdal_core:
 - '3.9'
 llvm_openmp:
 - '18'

--- a/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
@@ -28,7 +28,7 @@ gdal:
 - '3.9'
 hdf5:
 - 1.14.3
-libgdal:
+libgdal_core:
 - '3.9'
 llvm_openmp:
 - '18'

--- a/.ci_support/osx_64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.26python3.12.____cpython.yaml
@@ -28,7 +28,7 @@ gdal:
 - '3.9'
 hdf5:
 - 1.14.3
-libgdal:
+libgdal_core:
 - '3.9'
 llvm_openmp:
 - '18'

--- a/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
@@ -28,7 +28,7 @@ gdal:
 - '3.9'
 hdf5:
 - 1.14.3
-libgdal:
+libgdal_core:
 - '3.9'
 llvm_openmp:
 - '18'

--- a/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
@@ -28,7 +28,7 @@ gdal:
 - '3.9'
 hdf5:
 - 1.14.3
-libgdal:
+libgdal_core:
 - '3.9'
 llvm_openmp:
 - '18'

--- a/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
@@ -28,7 +28,7 @@ gdal:
 - '3.9'
 hdf5:
 - 1.14.3
-libgdal:
+libgdal_core:
 - '3.9'
 llvm_openmp:
 - '18'

--- a/.ci_support/osx_arm64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.26python3.12.____cpython.yaml
@@ -28,7 +28,7 @@ gdal:
 - '3.9'
 hdf5:
 - 1.14.3
-libgdal:
+libgdal_core:
 - '3.9'
 llvm_openmp:
 - '18'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "isce3" %}
 {% set version = "0.24.1" %}
-{% set number = 2 %}
+{% set number = 3 %}
 {% set isce3_proc_type = "cuda" if cuda_compiler_version != "None" else "cpu" %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,7 @@ outputs:
         - gtest
         - hdf5
         - libcufft-dev     # [(cuda_compiler_version or "").startswith("12")]
-        - libgdal
+        - libgdal-core
         - libgdal-hdf5
         - libgdal-netcdf
         - numpy


### PR DESCRIPTION
Depend on only the core part of libgdal, xref https://github.com/conda-forge/gdal-feedstock/issues/722#issuecomment-2204537063

A colleague of mine has been getting dependency conflict errors like this:

```
$ conda install -c conda-forge isce3=0.24.1
Channels:
 - conda-forge
Platform: linux-64
Collecting package metadata (repodata.json): done
Solving environment: / warning  libmamba Added empty dependency for problem type SOLVER_RULE_UPDATE
failed

LibMambaUnsatisfiableError: Encountered problems while solving:
  - package isce3-0.24.1-py312cuda118h1234567_2_cuda requires libgdal >=3.9.3,<3.10.0a0, but none of the providers can be installed

Could not solve for environment specs
The following packages are incompatible
├─ azure-core-cpp 1.13.0.*  is requested and can be installed;
├─ azure-identity-cpp 1.8.0.*  is requested and can be installed;
├─ isce3 0.24.1**  is installable with the potential options
│  ├─ isce3 0.24.1 would require
│  │  └─ python >=3.10,<3.11.0a0 , which can be installed;
│  ├─ isce3 0.24.1 would require
│  │  └─ python >=3.11,<3.12.0a0 , which can be installed;
│  ├─ isce3 0.24.1 would require
│  │  └─ libgdal >=3.9.3,<3.10.0a0 , which requires
│  │     └─ libgdal-tiledb 3.9.3.* , which requires
│  │        └─ tiledb >=2.26.2,<2.27.0a0  but there are no viable options
│  │           ├─ tiledb 2.26.2 would require
│  │           │  └─ azure-core-cpp >=1.14.0,<1.14.1.0a0 , which conflicts with any installable versions previously reported;
│  │           └─ tiledb 2.26.2 would require
│  │              └─ azure-identity-cpp >=1.9.0,<1.9.1.0a0 , which conflicts with any installable versions previously reported;
│  └─ isce3 0.24.1 would require
│     └─ python >=3.9,<3.10.0a0 , which can be installed;
└─ pin-1 is not installable because it requires
   └─ python 3.12.* , which conflicts with any installable versions previously reported.
```

Instead of depending on `libgdal` which pull in multiple sub-packages like `tiledb` (that probably isn't required by ISCE3), it's best to depend on `libgdal-core` + a few sub-packages that are actually needed. See also https://github.com/conda-forge/gdal-feedstock/issues/722#issuecomment-2204537063

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

See e.g. similar issue at https://github.com/conda-forge/rasterio-feedstock/issues/303